### PR TITLE
Fix console connection status

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,16 @@
     "ts-jest": "^24.0.2",
     "typedoc": "^0.15.0",
     "typescript": "^3.6.2"
-  }
+  },
+  "keywords": [
+    "project",
+    "slippi",
+    "smash",
+    "bros",
+    "melee",
+    "ssbm",
+    "slp",
+    "wii",
+    "connect"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "typescript": "^3.6.2"
   },
   "keywords": [
-    "project",
     "slippi",
     "smash",
     "bros",

--- a/src/console/connection.ts
+++ b/src/console/connection.ts
@@ -145,10 +145,9 @@ export class ConsoleConnection extends (EventEmitter as ConsoleConnectionEventEm
       host: this.ipAddress,
       port: this.port,
     }, () => {
-      console.log(`Connected to ${this.ipAddress}:${this.port}!`);
+      // console.log(`Instantiated connection to ${this.ipAddress}:${this.port}!`);
       clearTimeout(this.connectionRetryState.reconnectHandler);
       this._resetRetryState();
-      this._setStatus(ConnectionStatus.CONNECTED);
 
       const handshakeMsgOut = consoleComms.genHandshakeOut(
         this.connDetails.gameDataCursor, this.connDetails.clientToken
@@ -168,7 +167,8 @@ export class ConsoleConnection extends (EventEmitter as ConsoleConnectionEventEm
     client.on('data', (data) => {
       if (commState === CommunicationState.INITIAL) {
         commState = this._getInitialCommState(data);
-        console.log(`Connected to source with type: ${commState}`);
+        console.log(`Connected to ${this.ipAddress}:${this.port} with type: ${commState}`);
+        this._setStatus(ConnectionStatus.CONNECTED);
         // console.log(data.toString("hex"));
       }
 

--- a/src/console/connection.ts
+++ b/src/console/connection.ts
@@ -68,7 +68,7 @@ interface ConsoleConnectionEventEmitter {
  * const { ConsoleConnection } = require("@vinceau/slp-wii-connect");
  *
  * const connection = new ConsoleConnection();
- * connection.connect(address, port);
+ * connection.connect("localhost", 667); // You should set these values appropriately
  *
  * connection.on("data", (data) => {
  *   // Received data from console

--- a/src/console/connection.ts
+++ b/src/console/connection.ts
@@ -169,7 +169,7 @@ export class ConsoleConnection extends (EventEmitter as ConsoleConnectionEventEm
       if (commState === CommunicationState.INITIAL) {
         commState = this._getInitialCommState(data);
         console.log(`Connected to source with type: ${commState}`);
-        console.log(data.toString("hex"));
+        // console.log(data.toString("hex"));
       }
 
       if (commState === CommunicationState.LEGACY) {


### PR DESCRIPTION
Only return `Connected` when we receive the initial handshake.

Also reduce the number of console logs.